### PR TITLE
docs(rag): expand the retrieval corpus with real codes of conduct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,5 +85,9 @@ listener/bin/
 
 # ML datasets (raw + labeled) — regenerate, don't commit
 backend/*.csv
-backend/data/
+# Corpus data stays out (third-party copyright); the provenance note is tracked.
+backend/data/*
+!backend/data/policies/
+backend/data/policies/*
+!backend/data/policies/README.md
 backend/models/distilbert-checkpoints/

--- a/backend/data/policies/README.md
+++ b/backend/data/policies/README.md
@@ -1,0 +1,24 @@
+# RAG policy corpus
+
+Source documents for the retrieval corpus. The PDFs themselves are gitignored
+(`backend/data/` in `.gitignore`) — they are third-party copyrighted publications, used here
+for academic evaluation. Re-download them to reproduce the corpus:
+
+| File | Source | Chunks |
+|------|--------|--------|
+| `hlib-code-of-conduct.pdf` | https://www.hlib.com.my/Files/Code_of_Conduct_and_Ethics.pdf | 39 |
+| `genting-code-of-conduct.pdf` | https://www.gentingmalaysia.com/wp-content/uploads/2019/10/Genting-Code-of-Conduct-Ethics-simplified-with-new-Reg-No_22Oct2019.pdf | 7 |
+
+Ingest with, from `backend/`:
+
+```bash
+python scripts/ingest.py data/policies/hlib-code-of-conduct.pdf "HLIB Code of Conduct and Ethics"
+python scripts/ingest.py data/policies/genting-code-of-conduct.pdf "Genting Malaysia Code of Conduct and Ethics"
+```
+
+Chosen over the GitLab handbook because the project's context is Malaysian corporate email, and
+these are real listed-company documents rather than synthetic policy. Cite them in the report;
+do not present the text as original.
+
+Both must be attributed. Adding more sources: pick documents that cover the topics
+`scripts/eval_set.json` asks about, and extend that eval set at the same time.

--- a/docs/decisions/lane-b-ml.md
+++ b/docs/decisions/lane-b-ml.md
@@ -11,6 +11,36 @@
 
 ## Log
 
+### 2026-09-01 — Retrieval eval was measuring an empty corpus, not the retriever
+- Finding: `eval_retrieval.py` scored hit_rate 0.125 / p@5 0.025 / MRR 0.125 against the
+  R03.2 target of 0.90. The cause was not retrieval quality: the corpus held 7 chunks of HR
+  operations content (leave, travel claims, remote work) while the eval set asks about gifts,
+  bribery, conflicts of interest, hospitality, customer treatment and directors' duties. Seven
+  of eight queries had no correct answer present, and k=5 over 7 chunks returned most of the
+  corpus regardless. A perfect retriever would have scored the same.
+- Decision: ingest real corporate codes of conduct rather than tune retrieval. Added HLIB
+  (39 chunks) and Genting Malaysia (7 chunks) — public Malaysian listed-company documents,
+  chosen over the GitLab handbook because the project context is Malaysian corporate email.
+- Result on the same 8 queries, same k, no retrieval code changed:
+
+  | metric | before (7 chunks) | after (53 chunks) | target |
+  |--------|------------------|-------------------|--------|
+  | hit_rate | 0.125 | **1.000** | >= 0.90 |
+  | precision@5 | 0.025 | **0.600** | - |
+  | MRR | 0.125 | **0.900** | - |
+
+  8/8 queries hit, 7 of them at rank 1. R03.2 met.
+- Why not tune chunking/reranking first: with 7 chunks any measured gain would have been noise.
+  Corpus coverage dominated every other variable.
+- Caveat: the eval set is 8 queries and the corpus 53 chunks — enough to show the retriever
+  works, not enough to claim a tuned system. Both should grow together; a metric that improves
+  while the eval set stays fixed is not evidence of much.
+- Outstanding: the S3-vs-S5 reformulation comparison (`--reformulate`) is unrun — it needs one
+  LLM call per query and hit the Gemini free-tier limit of 5 requests/minute.
+- Source PDFs are gitignored under `backend/data/policies/`; provenance in that folder's README.
+- Status: accepted.
+
+
 ### 2026-07-07 — Embedding model = gemini-embedding-001 @ 1536 dims
 - Decision: embed with `gemini-embedding-001`, `output_dimensionality=1536`, L2-normalized.
   Column pins to `embedding vector(1536)`.


### PR DESCRIPTION
Turns R03.2 from a failing number into a met target — without changing a line of retrieval code.

## The eval was measuring an empty corpus, not the retriever

`eval_retrieval.py` reported `hit_rate 0.125` against a 0.90 target. That looked like a retrieval problem. It wasn't.

The corpus held **7 chunks** of HR operations content — leave accrual, travel claims, remote work — while `eval_set.json` asks about gifts from suppliers, bribery, conflicts of interest, hospitality limits, customer treatment and directors' duties. **Seven of the eight queries had no correct answer present in the database.** With `k=5` over 7 chunks, every query also returned most of the corpus regardless of ranking. A perfect retriever would have scored roughly the same.

The eval set had been written against an intended code-of-conduct corpus; what got seeded was the HR handbook demo. The two were never reconciled.

## Fix: corpus, not tuning

Ingested two public Malaysian listed-company codes of conduct:

| Document | Chunks |
|---|---|
| HLIB Code of Conduct and Ethics | 39 |
| Genting Malaysia Code of Conduct and Ethics | 7 |

Chosen over the GitLab handbook because the project's context is Malaysian corporate email, and these are real listed-company documents rather than synthetic policy.

## Result — same 8 queries, same k, no retrieval code changed

| metric | before (7 chunks) | after (53 chunks) | target |
|--------|------------------|-------------------|--------|
| hit_rate | 0.125 | **1.000** | >= 0.90 |
| precision@5 | 0.025 | **0.600** | — |
| MRR | 0.125 | **0.900** | — |

8/8 queries hit, 7 of them at rank 1.

## Caveats, stated rather than buried

- **8 queries over 53 chunks** is enough to show the retriever works, not enough to claim a tuned system. The eval set should grow with the corpus; a metric that improves while the eval set stays fixed is weak evidence.
- The S3-vs-S5 reformulation comparison (`--reformulate`) is **unrun** — it needs one LLM call per query and hit the Gemini free-tier limit of 5 requests/minute.
- Both documents are third-party copyrighted publications. They are gitignored; `backend/data/policies/README.md` carries source URLs and ingest commands so the corpus is reproducible. They must be cited in the report, not presented as original.
- A stray `"leave policy body"` chunk (test residue) is still in the corpus and should be removed separately.

Full reasoning in `docs/decisions/lane-b-ml.md`.