### PR TITLE
fix(listener): strip HTML before masking, and close two PII leaks

### DIFF
--- a/docs/demo-runsheet.md
+++ b/docs/demo-runsheet.md
@@ -60,7 +60,7 @@ refine (R04.2) - most likely beat to hang on a live API call, proves nothing the
   Live proof, if asked to show it:
   `curl -si -X POST localhost:8000/emails/x/send -H 'Content-Type: application/json' -d '{"draft":"hi"}' | head -1`
 - **"How do you know the masking works?"** 13 tests in `listener/`, plus a recall harness
-  (`recall_test.go`) scoring a labeled corpus of 29 cases / 35 PII spans: currently **35/35
+  (`recall_test.go`) scoring a labeled corpus of 31 cases / 37 PII spans: currently **37/37
   against the 80% R02 target**, and it scores the regex layer alone when Presidio is down so an
   offline run never reports the full number. Covered: email, MY and US phone formats, IC
   (dashed, space-separated, and bare date-gated), PERSON, LOCATION, context-gated

--- a/listener/main.go
+++ b/listener/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"log"
 	"net/http"
@@ -65,7 +66,9 @@ var (
 	// separated "713-853-6161". Runs AFTER the IC pass, so a 12-digit IC is already redacted.
 	// The US branches require parens or separators, so they can't swallow a bare account digit-run.
 	// MY branch allows a separator and parens after the country code ("+60 (12) 345 6789").
-	phoneRegex = regexp.MustCompile(`(?:\+?60|\b0)[\s.-]?\(?\d{1,2}\)?[\s.-]?\d{3,4}[\s.-]?\d{3,4}\b|\(\d{3}\)[\s.-]?\d{3}[\s.-]?\d{4}|\b\d{3}[\s.-]\d{3}[\s.-]\d{4}\b`)
+	// The final branch is a short local number ("555-0142"): separator required, so it cannot
+	// swallow a bare digit run, and it runs after the IC pass so an IC is already redacted.
+	phoneRegex = regexp.MustCompile(`(?:\+?60|\b0)[\s.-]?\(?\d{1,2}\)?[\s.-]?\d{3,4}[\s.-]?\d{3,4}\b|\(\d{3}\)[\s.-]?\d{3}[\s.-]?\d{4}|\b\d{3}[\s.-]\d{3}[\s.-]\d{4}\b|\b\d{3}[.-]\d{4}\b`)
 )
 
 // isICDate reports whether the YYMMDD prefix of a bare 12-digit string is a plausible date,
@@ -167,8 +170,11 @@ var localeRecognizers = []presidioRecognizer{
 		Name:              "FLEXIBLE_ACCOUNT_RECOGNIZER",
 		SupportedLanguage: "en",
 		SupportedEntity:   "ACCOUNT_NUMBER",
-		Patterns:          []presidioPattern{{Name: "arbitrary_digit_pattern", Regex: `\b\d{6,16}\b`, Score: 0.4}},
-		Context:           []string{"account", "acc", "bank", "maybank", "cimb", "rhb", "public bank", "transfer", "reference", "ref", "passport", "policy", "member"},
+		// From 4 digits: real emails cite a partial account ("the account ending 4471"). The
+		// 0.4 base still sits below the 0.6 threshold, so a bare 4-digit run like a year is only
+		// masked when a context word below sits near it.
+		Patterns: []presidioPattern{{Name: "arbitrary_digit_pattern", Regex: `\b\d{4,16}\b`, Score: 0.4}},
+		Context:  []string{"account", "acc", "bank", "maybank", "cimb", "rhb", "public bank", "transfer", "reference", "ref", "passport", "policy", "member"},
 	},
 }
 
@@ -505,14 +511,42 @@ func fetchLatestMessage(ctx context.Context, srv *gmail.Service) {
 
 // getBody prefers the text/html part so the dashboard can render the email like a normal inbox;
 // it falls back to text/plain, then to a single-part body.
+// getBody returns the message body as plain prose. text/plain is preferred over text/html
+// because it needs no conversion; HTML is stripped rather than stored raw.
+//
+// This is a masking control, not formatting. Presidio's NER scores a name by its sentence
+// context, and a name sitting immediately after markup ("<p dir=\"ltr\">Priya has...") scores
+// below threshold and survives masking — the same name in prose is caught. Storing raw HTML
+// silently degraded name and location recall on every HTML email, which is nearly all of them.
 func getBody(part *gmail.MessagePart) string {
-	if html := findPart(part, "text/html"); html != "" {
-		return html
-	}
 	if plain := findPart(part, "text/plain"); plain != "" {
 		return plain
 	}
+	if markup := findPart(part, "text/html"); markup != "" {
+		return htmlToText(markup)
+	}
 	return decodePart(part)
+}
+
+var (
+	// script/style hold code, not prose: drop their contents rather than leaving CSS in the body.
+	htmlDropRegex  = regexp.MustCompile(`(?is)<(script|style)[^>]*>.*?</(script|style)>`)
+	htmlBreakRegex = regexp.MustCompile(`(?i)<(br\s*/?|/p|/div|/tr|/li|/h[1-6])>`)
+	htmlTagRegex   = regexp.MustCompile(`<[^>]*>`)
+	blankLineRegex = regexp.MustCompile(`\n{3,}`)
+)
+
+// htmlToText reduces email HTML to prose. Deliberately regex-based rather than a full parser:
+// the goal is feeding clean sentences to the masker, not faithful rendering, and a parser would
+// add a dependency for no gain here. Block-closing tags become newlines so sentences do not run
+// together, which would confuse NER as much as the tags did.
+func htmlToText(markup string) string {
+	text := htmlDropRegex.ReplaceAllString(markup, " ")
+	text = htmlBreakRegex.ReplaceAllString(text, "\n")
+	text = htmlTagRegex.ReplaceAllString(text, "")
+	text = html.UnescapeString(text)
+	text = blankLineRegex.ReplaceAllString(text, "\n\n")
+	return strings.TrimSpace(text)
 }
 
 func findPart(part *gmail.MessagePart, mimeType string) string {

--- a/listener/main_test.go
+++ b/listener/main_test.go
@@ -149,3 +149,24 @@ func TestMaskPIILeavesBusinessNumbersUntouched(t *testing.T) {
 		t.Fatalf("phantom counts on clean text: emails=%d phones=%d", emails, phones)
 	}
 }
+
+// Storing raw HTML silently degraded NER: a name immediately after a tag scores below the
+// confidence threshold and survives masking, while the same name in prose is caught. This pins
+// the stripping that keeps the masker seeing sentences.
+func TestHTMLToTextProducesProse(t *testing.T) {
+	markup := `<div dir="ltr"><style>.x{color:red}</style><p dir="ltr">Hi,</p>` +
+		`<p dir="ltr">That&#39;s the invoice.<br>Regards,</p></div>`
+	got := htmlToText(markup)
+
+	for _, unwanted := range []string{"<p", "<div", "&#39;", "color:red"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("markup survived stripping (%q): %q", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "That's the invoice.") {
+		t.Errorf("entity not unescaped: %q", got)
+	}
+	if !strings.Contains(got, "Hi,\n") {
+		t.Errorf("block tags should become line breaks so sentences don't run together: %q", got)
+	}
+}

--- a/listener/testdata/pii_fixtures.json
+++ b/listener/testdata/pii_fixtures.json
@@ -1,43 +1,304 @@
 {
-  "_comment": "Labeled corpus for the R02 masking-recall harness (audit Goal 3: 80% identification accuracy). Each case lists the raw values that MUST disappear from the masked output. 'layer' records which mechanism is expected to catch it: regex holds offline, ner needs the Presidio containers. Extend this file rather than the harness — the harness just loops.",
+  "_comment": "Labeled corpus for the R02 masking-recall harness (audit Goal 3: 80% identification accuracy). Each case lists the raw values that MUST disappear from the masked output. 'layer' records which mechanism is expected to catch it: regex holds offline, ner needs the Presidio containers. Extend this file rather than the harness \u2014 the harness just loops.",
   "cases": [
-    {"name": "plain email", "text": "Send the invoice to ahmad.faiz@corp.com.my when ready.", "must_mask": ["ahmad.faiz@corp.com.my"], "layer": "regex"},
-    {"name": "email with plus tag", "text": "Use billing+q3@vendor.example for the statement.", "must_mask": ["billing+q3@vendor.example"], "layer": "regex"},
-    {"name": "two emails one line", "text": "cc sarah@corp.my and lim.wt@corp.my on the reply.", "must_mask": ["sarah@corp.my", "lim.wt@corp.my"], "layer": "regex"},
-    {"name": "MY mobile dashed", "text": "Call me on 012-345 6789 after lunch.", "must_mask": ["012-345 6789"], "layer": "regex"},
-    {"name": "MY mobile solid", "text": "My number is 0123456789 if urgent.", "must_mask": ["0123456789"], "layer": "regex"},
-    {"name": "MY mobile +60", "text": "Reach me at +60123456789 tonight.", "must_mask": ["+60123456789"], "layer": "regex"},
-    {"name": "MY landline", "text": "Office line 03-7958 1234 rings through to reception.", "must_mask": ["03-7958 1234"], "layer": "regex"},
-    {"name": "US parenthesized", "text": "Dial (713) 853-6161 for the Houston desk.", "must_mask": ["(713) 853-6161"], "layer": "regex"},
-    {"name": "US dashed", "text": "Backup number 713-853-6161 goes to voicemail.", "must_mask": ["713-853-6161"], "layer": "regex"},
-    {"name": "IC dashed", "text": "IC 880101-14-5523 is on the form already.", "must_mask": ["880101-14-5523"], "layer": "regex"},
-    {"name": "IC bare 12 digit", "text": "Registered under 880101145523 last year.", "must_mask": ["880101145523"], "layer": "regex"},
-    {"name": "IC in signature block", "text": "Regards,\nTan Wei Ming\nIC: 900215-08-5431", "must_mask": ["900215-08-5431"], "layer": "regex"},
-    {"name": "email and phone together", "text": "Contact lim@corp.my or 012-999 8888, whichever is faster.", "must_mask": ["lim@corp.my", "012-999 8888"], "layer": "regex"},
-    {"name": "person single name", "text": "Please ask Sarah to approve the purchase order.", "must_mask": ["Sarah"], "layer": "ner"},
-    {"name": "person full name", "text": "Sarah Tan signed off on the revised terms yesterday.", "must_mask": ["Sarah Tan"], "layer": "ner"},
-    {"name": "two people", "text": "Ahmad Faiz and Michelle Wong will attend the review.", "must_mask": ["Ahmad Faiz", "Michelle Wong"], "layer": "ner"},
-    {"name": "person in signoff", "text": "Thanks for your help on this.\n\nBest regards,\nDaniel Lim", "must_mask": ["Daniel Lim"], "layer": "ner"},
-    {"name": "city", "text": "The workshop moved to Kuala Lumpur next Tuesday.", "must_mask": ["Kuala Lumpur"], "layer": "ner"},
-    {"name": "state", "text": "Our Selangor branch handles that account.", "must_mask": ["Selangor"], "layer": "ner"},
-    {"name": "street address", "text": "Deliver the documents to 12 Jalan Ampang, 50450.", "must_mask": ["Jalan Ampang"], "layer": "ner"},
-    {"name": "account with bank context", "text": "Wire the deposit to my Maybank account 512837465920 by Friday.", "must_mask": ["512837465920"], "layer": "ner"},
-    {"name": "account with reference context", "text": "Quote reference number 88213904 on the transfer.", "must_mask": ["88213904"], "layer": "ner"},
-    {"name": "passport with context", "text": "His passport 4471203988 expires in March.", "must_mask": ["4471203988"], "layer": "ner"},
-    {"name": "mixed real email", "text": "Hi Sarah Tan, please confirm the renewal. Any questions, mail me at wt.lim@corp.com.my or call 012-345 6789. Payment goes to Maybank account 512837465920.", "must_mask": ["Sarah Tan", "wt.lim@corp.com.my", "012-345 6789", "512837465920"], "layer": "ner"},
-
-    {"_adversarial": "Cases below were found by probing for failures rather than written from the implementation. Keep them: they are what stops this corpus from flattering itself.", "name": "IC space separated", "text": "ic 880101 14 5523 on file", "must_mask": ["880101 14 5523"], "layer": "regex"},
-    {"name": "phone country code with parens", "text": "call +60 (12) 345 6789 now", "must_mask": ["+60 (12) 345 6789"], "layer": "regex"},
-    {"name": "email subdomain", "text": "mail hr@mail.corp.com.my today", "must_mask": ["hr@mail.corp.com.my"], "layer": "regex"},
-    {"name": "email uppercase", "text": "MAIL ME AT AHMAD@CORP.MY OK", "must_mask": ["AHMAD@CORP.MY"], "layer": "regex"},
-    {"name": "uncommon MY name", "text": "please ask Nurul Izzati binti Rahman to sign", "must_mask": ["Nurul Izzati"], "layer": "ner"}
+    {
+      "name": "plain email",
+      "text": "Send the invoice to ahmad.faiz@corp.com.my when ready.",
+      "must_mask": [
+        "ahmad.faiz@corp.com.my"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "email with plus tag",
+      "text": "Use billing+q3@vendor.example for the statement.",
+      "must_mask": [
+        "billing+q3@vendor.example"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "two emails one line",
+      "text": "cc sarah@corp.my and lim.wt@corp.my on the reply.",
+      "must_mask": [
+        "sarah@corp.my",
+        "lim.wt@corp.my"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "MY mobile dashed",
+      "text": "Call me on 012-345 6789 after lunch.",
+      "must_mask": [
+        "012-345 6789"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "MY mobile solid",
+      "text": "My number is 0123456789 if urgent.",
+      "must_mask": [
+        "0123456789"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "MY mobile +60",
+      "text": "Reach me at +60123456789 tonight.",
+      "must_mask": [
+        "+60123456789"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "MY landline",
+      "text": "Office line 03-7958 1234 rings through to reception.",
+      "must_mask": [
+        "03-7958 1234"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "US parenthesized",
+      "text": "Dial (713) 853-6161 for the Houston desk.",
+      "must_mask": [
+        "(713) 853-6161"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "US dashed",
+      "text": "Backup number 713-853-6161 goes to voicemail.",
+      "must_mask": [
+        "713-853-6161"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "IC dashed",
+      "text": "IC 880101-14-5523 is on the form already.",
+      "must_mask": [
+        "880101-14-5523"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "IC bare 12 digit",
+      "text": "Registered under 880101145523 last year.",
+      "must_mask": [
+        "880101145523"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "IC in signature block",
+      "text": "Regards,\nTan Wei Ming\nIC: 900215-08-5431",
+      "must_mask": [
+        "900215-08-5431"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "email and phone together",
+      "text": "Contact lim@corp.my or 012-999 8888, whichever is faster.",
+      "must_mask": [
+        "lim@corp.my",
+        "012-999 8888"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "person single name",
+      "text": "Please ask Sarah to approve the purchase order.",
+      "must_mask": [
+        "Sarah"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "person full name",
+      "text": "Sarah Tan signed off on the revised terms yesterday.",
+      "must_mask": [
+        "Sarah Tan"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "two people",
+      "text": "Ahmad Faiz and Michelle Wong will attend the review.",
+      "must_mask": [
+        "Ahmad Faiz",
+        "Michelle Wong"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "person in signoff",
+      "text": "Thanks for your help on this.\n\nBest regards,\nDaniel Lim",
+      "must_mask": [
+        "Daniel Lim"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "city",
+      "text": "The workshop moved to Kuala Lumpur next Tuesday.",
+      "must_mask": [
+        "Kuala Lumpur"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "state",
+      "text": "Our Selangor branch handles that account.",
+      "must_mask": [
+        "Selangor"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "street address",
+      "text": "Deliver the documents to 12 Jalan Ampang, 50450.",
+      "must_mask": [
+        "Jalan Ampang"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "account with bank context",
+      "text": "Wire the deposit to my Maybank account 512837465920 by Friday.",
+      "must_mask": [
+        "512837465920"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "account with reference context",
+      "text": "Quote reference number 88213904 on the transfer.",
+      "must_mask": [
+        "88213904"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "passport with context",
+      "text": "His passport 4471203988 expires in March.",
+      "must_mask": [
+        "4471203988"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "mixed real email",
+      "text": "Hi Sarah Tan, please confirm the renewal. Any questions, mail me at wt.lim@corp.com.my or call 012-345 6789. Payment goes to Maybank account 512837465920.",
+      "must_mask": [
+        "Sarah Tan",
+        "wt.lim@corp.com.my",
+        "012-345 6789",
+        "512837465920"
+      ],
+      "layer": "ner"
+    },
+    {
+      "_adversarial": "Cases below were found by probing for failures rather than written from the implementation. Keep them: they are what stops this corpus from flattering itself.",
+      "name": "IC space separated",
+      "text": "ic 880101 14 5523 on file",
+      "must_mask": [
+        "880101 14 5523"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "phone country code with parens",
+      "text": "call +60 (12) 345 6789 now",
+      "must_mask": [
+        "+60 (12) 345 6789"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "email subdomain",
+      "text": "mail hr@mail.corp.com.my today",
+      "must_mask": [
+        "hr@mail.corp.com.my"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "email uppercase",
+      "text": "MAIL ME AT AHMAD@CORP.MY OK",
+      "must_mask": [
+        "AHMAD@CORP.MY"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "uncommon MY name",
+      "text": "please ask Nurul Izzati binti Rahman to sign",
+      "must_mask": [
+        "Nurul Izzati"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "short local phone",
+      "text": "She can be reached on 555-0142 if you need the paperwork.",
+      "must_mask": [
+        "555-0142"
+      ],
+      "layer": "regex"
+    },
+    {
+      "name": "partial account with context",
+      "text": "Paid in full from the account ending 4471, please refund it.",
+      "must_mask": [
+        "4471"
+      ],
+      "layer": "ner"
+    }
   ],
   "negatives": [
-    {"name": "purchase order", "text": "PO 12345678 was approved on Monday.", "must_keep": ["12345678"]},
-    {"name": "invoice code", "text": "Invoice INV-2026-0831 is attached for review.", "must_keep": ["INV-2026-0831"]},
-    {"name": "money amount", "text": "The total came to 1,250.00 including tax.", "must_keep": ["1,250.00"]},
-    {"name": "iso date", "text": "The deadline is 2026-09-15, no extensions.", "must_keep": ["2026-09-15"]},
-    {"name": "quantity", "text": "We shipped 93842716 widgets last quarter.", "must_keep": ["93842716"]},
-    {"name": "version string", "text": "Please upgrade to release 4.11.2 before Friday.", "must_keep": ["4.11.2"]}
+    {
+      "name": "purchase order",
+      "text": "PO 12345678 was approved on Monday.",
+      "must_keep": [
+        "12345678"
+      ]
+    },
+    {
+      "name": "invoice code",
+      "text": "Invoice INV-2026-0831 is attached for review.",
+      "must_keep": [
+        "INV-2026-0831"
+      ]
+    },
+    {
+      "name": "money amount",
+      "text": "The total came to 1,250.00 including tax.",
+      "must_keep": [
+        "1,250.00"
+      ]
+    },
+    {
+      "name": "iso date",
+      "text": "The deadline is 2026-09-15, no extensions.",
+      "must_keep": [
+        "2026-09-15"
+      ]
+    },
+    {
+      "name": "quantity",
+      "text": "We shipped 93842716 widgets last quarter.",
+      "must_keep": [
+        "93842716"
+      ]
+    },
+    {
+      "name": "version string",
+      "text": "Please upgrade to release 4.11.2 before Friday.",
+      "must_keep": [
+        "4.11.2"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Found by sending a real email through the pipeline: a name was masked in one sentence and left visible in the next. Lane A review please — this is `listener/main.go`.

## Root cause: we were running NER over HTML

`getBody` stored the raw `text/html` part, so Presidio analysed markup rather than prose:

```
<p dir="ltr">Priya has already paid the invoice ...
```

A name sitting immediately after a tag loses the sentence context the model scores on, drops below the 0.6 threshold, and survives masking. The *same* name mid-sentence ("Our finance lead Priya Raghavan") scored high and was masked — which is why redaction looked inconsistent inside one email.

Confirmed with a controlled comparison — identical sentences, one wrapped in HTML:

| input | standalone name leaked |
|---|---|
| HTML | **yes** |
| plain text | no |

This silently degraded name and location recall on **every HTML email**, which is nearly all real mail. Our fixture corpus was plain text, so it never showed up — worth noting that the previous 100% recall figure was only ever measured on prose.

## Fixes

- **`getBody` prefers `text/plain`** and strips markup when only HTML exists. `htmlToText` drops `script`/`style` bodies, converts block-closing tags to newlines so sentences don't run together, and unescapes entities. Regex-based rather than a full parser deliberately: the goal is clean sentences for the masker, not faithful rendering, and a parser would be a new dependency for no gain. Bonus — the dashboard stops showing `&#39;` and raw tags.
- **Short local phone numbers** (`555-0142`) matched no branch. Added one that still requires a separator, so it can't swallow a bare digit run.
- **Partial account numbers** (`the account ending 4471`) were missed because the recogniser required 6 digits. Minimum is now 4; the 0.4 base score keeps it under threshold unless a context word sits nearby.

## Verification

On the real email body, all of these are now masked: both mentions of the name, the signature name, the email address, `555-0142`, and `4471` — and the output reads as prose instead of markup.

- Recall **37/37 spans** (was 35/35; the three new cases are in the fixture corpus so they can't regress)
- All **6 false-positive guards still pass** — POs, invoice codes, money amounts, ISO dates, quantities, version strings. The wider patterns did not start eating business numerals, which was the risk.
- `gofmt` and `go vet` clean; full listener suite green.