### PR TITLE
fix(listener): add card detection, stop masking countries, catch employee numbers

### DIFF
--- a/docs/decisions/lane-a-spine.md
+++ b/docs/decisions/lane-a-spine.md
@@ -11,4 +11,24 @@
 
 ## Log
 
+### 2026-09-03 — Country and state names are kept; cities and streets stay masked
+- Decision: `LOCATION` hits naming a country or a Malaysian state are filtered out of the Presidio
+  results before anonymising (`allowedLocations` in `listener/main.go`). Cities, districts and
+  street names continue to be masked.
+- Why: an adversarial test email produced "The [Redacted] desk" from "The US desk". A country or
+  state in business mail is organisational context, not personal data — masking it strips meaning
+  from the draft the model then writes, without protecting anyone. Confirmed the same for UK,
+  Singapore, Malaysia and Selangor.
+- Why not drop LOCATION entirely: that would stop masking cities, and "Kuala Lumpur" beside a
+  person's name is identifying in a way "Malaysia" is not.
+- Why not extend the list to cities: it would punch a hole in the privacy claim. The boundary errs
+  conservative — anything ambiguous stays redacted. Keep the list short.
+- Note: one earlier fixture expected `Selangor` to be masked. It contradicted this policy and was
+  retired; the recall harness surfaced the conflict rather than silently reporting a miss.
+- Affects: Lane A. Two other changes shipped alongside — `CREDIT_CARD` added to the requested
+  entities (Luhn-validated, so it cannot fire on invoice numbers), and employee/staff/payroll added
+  to the account recogniser's context words.
+- Status: accepted — JiaJun review pending as lane owner.
+
+
 _No entries yet. Add newest-first using the template in [`README.md`](README.md)._

--- a/listener/main.go
+++ b/listener/main.go
@@ -174,8 +174,42 @@ var localeRecognizers = []presidioRecognizer{
 		// 0.4 base still sits below the 0.6 threshold, so a bare 4-digit run like a year is only
 		// masked when a context word below sits near it.
 		Patterns: []presidioPattern{{Name: "arbitrary_digit_pattern", Regex: `\b\d{4,16}\b`, Score: 0.4}},
-		Context:  []string{"account", "acc", "bank", "maybank", "cimb", "rhb", "public bank", "transfer", "reference", "ref", "passport", "policy", "member"},
+		Context:  []string{"account", "acc", "bank", "maybank", "cimb", "rhb", "public bank", "transfer", "reference", "ref", "passport", "policy", "member", "employee", "emp", "staff", "badge", "payroll"},
 	},
+}
+
+// allowedLocations are place names kept in the text rather than redacted. A country or state in
+// business mail is organisational context, not personal data: masking "the US desk" or "our
+// Selangor branch" strips meaning from the draft the model then writes, without protecting
+// anyone. The boundary is country and state only — cities, districts and streets stay masked, so
+// anything ambiguous errs toward redaction. Keep this list short; extending it to cities would
+// punch holes in the privacy claim. Recorded in docs/decisions/lane-a-spine.md.
+var allowedLocations = map[string]bool{
+	"us": true, "u.s.": true, "u.s.a.": true, "usa": true, "america": true,
+	"uk": true, "u.k.": true, "britain": true, "eu": true, "apac": true, "asean": true,
+	"malaysia": true, "singapore": true, "indonesia": true, "thailand": true,
+	"australia": true, "india": true, "china": true, "japan": true,
+	// Malaysian states — "our Selangor branch" is a business unit, not a person's address.
+	"selangor": true, "penang": true, "johor": true, "sabah": true, "sarawak": true,
+	"melaka": true, "malacca": true, "perak": true, "pahang": true, "kedah": true,
+	"kelantan": true, "terengganu": true, "perlis": true, "negeri sembilan": true,
+}
+
+// filterAllowedLocations drops LOCATION hits naming a country or state, leaving every other
+// entity untouched. Offsets from Presidio are Python character indices, so the text is sliced as
+// runes — byte slicing would misalign the moment an email contains a non-ASCII character.
+func filterAllowedLocations(text string, results []presidioResult) []presidioResult {
+	runes := []rune(text)
+	kept := make([]presidioResult, 0, len(results))
+	for _, r := range results {
+		if r.EntityType == "LOCATION" && r.Start >= 0 && r.End <= len(runes) && r.Start < r.End {
+			if allowedLocations[strings.ToLower(strings.TrimSpace(string(runes[r.Start:r.End])))] {
+				continue
+			}
+		}
+		kept = append(kept, r)
+	}
+	return kept
 }
 
 // maskText applies the regex PII floor first (always, offline-proof), then layers Presidio
@@ -202,10 +236,12 @@ func maskWithPresidio(ctx context.Context, text string) (string, error) {
 	anonymizerURL := getEnvOrDefault("PRESIDIO_ANONYMIZER_URL", "http://localhost:5002/anonymize")
 
 	analyzePayload, err := json.Marshal(presidioAnalyzeRequest{
-		Text:             text,
-		Language:         "en",
-		ScoreThreshold:   0.6,
-		Entities:         []string{"PERSON", "LOCATION", "ORGANIZATION", "ACCOUNT_NUMBER"},
+		Text:           text,
+		Language:       "en",
+		ScoreThreshold: 0.6,
+		// CREDIT_CARD is Presidio's built-in recogniser and validates the Luhn checksum, so it
+		// cannot fire on an invoice or order number that merely looks card-shaped.
+		Entities:         []string{"PERSON", "LOCATION", "ORGANIZATION", "ACCOUNT_NUMBER", "CREDIT_CARD"},
 		AdHocRecognizers: localeRecognizers,
 	})
 	if err != nil {
@@ -220,6 +256,7 @@ func maskWithPresidio(ctx context.Context, text string) (string, error) {
 	if err := json.Unmarshal(raw, &results); err != nil {
 		return "", fmt.Errorf("decode analyze results: %w", err)
 	}
+	results = filterAllowedLocations(text, results)
 	if len(results) == 0 {
 		return text, nil // no PII beyond the regex floor
 	}

--- a/listener/main_test.go
+++ b/listener/main_test.go
@@ -170,3 +170,52 @@ func TestHTMLToTextProducesProse(t *testing.T) {
 		t.Errorf("block tags should become line breaks so sentences don't run together: %q", got)
 	}
 }
+
+// Country and state names are business context, not personal data — masking "the US desk" strips
+// meaning from the draft without protecting anyone. Cities stay masked, so the boundary holds.
+func TestFilterAllowedLocationsKeepsCountriesAndStates(t *testing.T) {
+	text := "The US desk and the Selangor branch both report to Kuala Lumpur."
+	span := func(s string) (int, int) { i := strings.Index(text, s); return i, i + len(s) }
+	usStart, usEnd := span("US")
+	selStart, selEnd := span("Selangor")
+	klStart, klEnd := span("Kuala Lumpur")
+
+	results := []presidioResult{
+		{EntityType: "LOCATION", Start: usStart, End: usEnd},
+		{EntityType: "LOCATION", Start: selStart, End: selEnd},
+		{EntityType: "LOCATION", Start: klStart, End: klEnd},
+		{EntityType: "PERSON", Start: usStart, End: usEnd}, // a PERSON hit is never filtered
+	}
+	kept := filterAllowedLocations(text, results)
+
+	if len(kept) != 2 {
+		t.Fatalf("expected the city and the PERSON hit to survive, got %d: %+v", len(kept), kept)
+	}
+	if kept[0].EntityType != "LOCATION" || text[kept[0].Start:kept[0].End] != "Kuala Lumpur" {
+		t.Errorf("the city should still be masked, got %+v", kept[0])
+	}
+	if kept[1].EntityType != "PERSON" {
+		t.Errorf("non-LOCATION entities must pass through untouched, got %+v", kept[1])
+	}
+}
+
+// Offsets from Presidio are Python character indices; slicing bytes would misalign on any
+// non-ASCII character and could panic or filter the wrong span.
+func TestFilterAllowedLocationsHandlesNonASCII(t *testing.T) {
+	text := "Café notes: the US desk replied."
+	usStart := len([]rune("Café notes: the "))
+	results := []presidioResult{{EntityType: "LOCATION", Start: usStart, End: usStart + 2}}
+
+	if kept := filterAllowedLocations(text, results); len(kept) != 0 {
+		t.Fatalf("expected US to be filtered despite the non-ASCII prefix, got %+v", kept)
+	}
+}
+
+// A span outside the text must not panic — Presidio is a separate service and its offsets are
+// only as trustworthy as the payload we got back.
+func TestFilterAllowedLocationsIgnoresOutOfRangeSpans(t *testing.T) {
+	results := []presidioResult{{EntityType: "LOCATION", Start: 0, End: 999}}
+	if kept := filterAllowedLocations("short", results); len(kept) != 1 {
+		t.Fatalf("an unusable span should be kept, not dropped or fatal: %+v", kept)
+	}
+}

--- a/listener/testdata/pii_fixtures.json
+++ b/listener/testdata/pii_fixtures.json
@@ -149,14 +149,6 @@
       "layer": "ner"
     },
     {
-      "name": "state",
-      "text": "Our Selangor branch handles that account.",
-      "must_mask": [
-        "Selangor"
-      ],
-      "layer": "ner"
-    },
-    {
       "name": "street address",
       "text": "Deliver the documents to 12 Jalan Ampang, 50450.",
       "must_mask": [
@@ -255,6 +247,22 @@
         "4471"
       ],
       "layer": "ner"
+    },
+    {
+      "name": "credit card luhn valid",
+      "text": "The corporate card 4532 0151 1283 0366 is on file.",
+      "must_mask": [
+        "4532 0151 1283 0366"
+      ],
+      "layer": "ner"
+    },
+    {
+      "name": "employee number with context",
+      "text": "Our compliance officer (employee no. 4471) needs the paperwork.",
+      "must_mask": [
+        "4471"
+      ],
+      "layer": "ner"
     }
   ],
   "negatives": [
@@ -298,6 +306,34 @@
       "text": "Please upgrade to release 4.11.2 before Friday.",
       "must_keep": [
         "4.11.2"
+      ]
+    },
+    {
+      "name": "country name kept",
+      "text": "The US desk can confirm on Monday.",
+      "must_keep": [
+        "US"
+      ]
+    },
+    {
+      "name": "state name kept",
+      "text": "The Selangor branch signed off already.",
+      "must_keep": [
+        "Selangor"
+      ]
+    },
+    {
+      "name": "card shaped but luhn invalid",
+      "text": "Order code 4539 8712 3344 1122 shipped.",
+      "must_keep": [
+        "4539 8712 3344 1122"
+      ]
+    },
+    {
+      "name": "employee count not an id",
+      "text": "We have 240 employees across the region.",
+      "must_keep": [
+        "240"
       ]
     }
   ]


### PR DESCRIPTION
Three gaps found by sending a deliberately adversarial email through the live pipeline and auditing every span. Lane A review please — and change 2 is a policy boundary, not just code, so it wants your sign-off specifically.

## 1. Credit cards were never detected

`CREDIT_CARD` was simply not in the requested entity list, so Presidio's recogniser never ran. Enabling it is one line.

Safe because it **validates the Luhn checksum** rather than matching digit shape — verified against every existing negative control plus a card-shaped but Luhn-invalid number, which is correctly left alone. (The number in our first test email was itself Luhn-invalid, which is why enabling the entity alone didn't appear to fix it — checksum computed by hand to confirm.)

## 2. Country and state names were being masked

"The US desk" became "The **[Redacted]** desk". Same for UK, Singapore, Malaysia, Selangor.

A country or state in business mail is organisational context, not personal data — redacting it strips meaning from the draft the model then writes, without protecting anyone. `LOCATION` hits matching a short allow-list are now filtered before anonymising.

**The boundary is country and state only.** Cities, districts and streets still mask — "Kuala Lumpur" beside a person's name is identifying in a way "Malaysia" is not. The list is deliberately short; extending it to cities would punch a hole in the privacy claim. Reasoning recorded in `docs/decisions/lane-a-spine.md`.

## 3. Employee numbers leaked

`EMP-4471` survived. The digits already matched the account pattern; no nearby word was in its context list. Added `employee`, `emp`, `staff`, `badge`, `payroll` — reusing the existing context gate rather than inventing a second mechanism, so the 0.4 base score still keeps bare numbers below threshold.

## Implementation note worth reviewing

Presidio returns **Python character offsets**. The filter slices runes, not bytes — byte slicing would misalign on the first non-ASCII character in an email and could filter the wrong span. There's a test for that, plus one for an out-of-range span (Presidio is a separate service; its offsets are only as trustworthy as the payload).

## A fixture contradiction the harness caught

An earlier fixture expected `Selangor` to be masked, which directly contradicts the new policy. The recall harness surfaced it as a named miss rather than silently reporting a lower number. The positive expectation was retired and the negative control added alongside the policy now holds.

## Verification

- Recall **38/38 spans**, **10 negative controls** passing (4 new: country kept, state kept, Luhn-invalid kept, employee count kept)
- End-to-end on the full audit email: **12 of 12 PII items masked, 8 of 8 controls preserved**, including `US` now surviving
- `gofmt`, `go vet` clean

## Still open, deliberately

Street numbers ("12 Jalan Ampang" keeps the 12) — an address pattern would collide with dates and clause numbers, which is what the negative controls exist to prevent. Organisation names stay off by existing decision.